### PR TITLE
Add snapshot types and RecipesBase plot recipes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,10 +15,14 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [weakdeps]
 Gridap = "56d4f2e9-7ea1-5844-9cf6-b9c51ca7ce8e"
 OpenCALPHAD = "f22b17f6-ccb9-4067-ab50-5d8cfb3cb77d"
+PythonPlot = "274fc56d-3b97-40fa-a1cd-1b4a50311bf9"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 
 [extensions]
 GridapExt = "Gridap"
 OpenCALPHADExt = "OpenCALPHAD"
+PhaseFieldsPythonPlotExt = "PythonPlot"
+PhaseFieldsRecipesBaseExt = "RecipesBase"
 
 [compat]
 DiffEqCallbacks = "4"
@@ -27,6 +31,8 @@ ForwardDiff = "0.10"
 Gridap = "0.17, 0.18"
 OpenCALPHAD = "0.1"
 OrdinaryDiffEq = "6"
+PythonPlot = "1"
+RecipesBase = "1"
 SciMLBase = "2"
 julia = "1.10"
 

--- a/ext/PhaseFieldsRecipesBaseExt.jl
+++ b/ext/PhaseFieldsRecipesBaseExt.jl
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026 Hiroharu Sugawara
+# Part of PhaseFields.jl - RecipesBase extension
+
+module PhaseFieldsRecipesBaseExt
+
+using RecipesBase
+using PhaseFields: FieldSnapshot1D, SpaceTimeSnapshot1D, FieldSnapshot2D
+
+@recipe function f(snap::FieldSnapshot1D)
+    n = length(snap.fields)
+    if n == 1
+        sym, vals = snap.fields[1]
+        xlabel --> snap.xlabel
+        ylabel --> string(sym)
+        title  --> (snap.title == "" ? "$(sym) (t=$(snap.t))" : snap.title)
+        linewidth --> 2
+        snap.x, vals
+    else
+        layout := (n, 1)
+        for (i, (sym, vals)) in enumerate(snap.fields)
+            @series begin
+                subplot := i
+                xlabel --> (i == n ? snap.xlabel : "")
+                ylabel --> string(sym)
+                title  --> (i == 1 && snap.title != "" ? snap.title : "")
+                linewidth --> 2
+                snap.x, vals
+            end
+        end
+    end
+end
+
+@recipe function f(snap::SpaceTimeSnapshot1D)
+    seriestype := :heatmap
+    xlabel --> snap.xlabel
+    ylabel --> snap.ylabel
+    title  --> (snap.title == "" ? string(snap.field_name) : snap.title)
+    seriescolor --> snap.colormap
+    if snap.clims !== nothing
+        clims --> snap.clims
+    end
+    snap.t, snap.x, snap.data
+end
+
+@recipe function f(snap::FieldSnapshot2D)
+    seriestype := :heatmap
+    xlabel --> snap.xlabel
+    ylabel --> snap.ylabel
+    title  --> (snap.title == "" ? "$(snap.field_name) (t=$(snap.t))" : snap.title)
+    aspect_ratio --> :equal
+    seriescolor --> snap.colormap
+    if snap.clims !== nothing
+        clims --> snap.clims
+    end
+    snap.x, snap.y, snap.field'
+end
+
+end # module

--- a/src/PhaseFields.jl
+++ b/src/PhaseFields.jl
@@ -53,6 +53,10 @@ include("integration/callbacks.jl")
 # Problem solvers (must be after diffeq.jl for UniformGrid1D)
 include("problems/solvers.jl")
 
+# Snapshot types for plotting (must be after diffeq.jl for grid types)
+include("snapshot.jl")
+include("plotting.jl")
+
 # =============================================================================
 # Gridap Extension - Placeholder for extension
 # These are implemented by ext/GridapExt.jl when Gridap is loaded
@@ -263,6 +267,10 @@ export extract_thermal_solution
 export WBMODEParams, wbm_ode!
 export CahnHilliardODEParams, cahn_hilliard_ode!
 export KKSODEParams, kks_ode!
+
+# Exports - Snapshot types (for plotting)
+export FieldSnapshot1D, SpaceTimeSnapshot1D, FieldSnapshot2D
+export plot_field, animate_field, savefig_publication
 
 # Exports - Callbacks
 export interface_position_1d, solid_fraction

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026 Hiroharu Sugawara
+# Part of PhaseFields.jl - Plotting stubs
+#
+# Implementations in extensions:
+#   ext/PhaseFieldsRecipesBaseExt.jl (RecipesBase recipes)
+#   ext/PhaseFieldsPlotsExt.jl       (plot_field, animate_field)
+#   ext/PhaseFieldsPythonPlotExt.jl  (savefig_publication)
+
+"""
+    plot_field(snap; kwargs...)
+
+Plot a field snapshot. Requires `using Plots`.
+"""
+function plot_field end
+
+"""
+    animate_field(snaps; fps=10, kwargs...)
+
+Create animation from snapshots. Requires `using Plots`.
+"""
+function animate_field end
+
+"""
+    savefig_publication(snap, filepath; kwargs...)
+
+Save publication-quality figure. Requires `using PythonPlot`.
+"""
+function savefig_publication end
+
+# Fallback
+function savefig_publication(args...; kwargs...)
+    throw(ArgumentError(
+        "savefig_publication requires PythonPlot.jl. Run `using PythonPlot` first."
+    ))
+end

--- a/src/snapshot.jl
+++ b/src/snapshot.jl
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026 Hiroharu Sugawara
+# Part of PhaseFields.jl - Snapshot types for plotting
+
+"""
+    FieldSnapshot1D
+
+1D field snapshot at a specific time. Holds one or more named fields.
+
+# Fields
+- `x::Vector{Float64}` — spatial coordinates
+- `fields::Vector{Pair{Symbol,Vector{Float64}}}` — field data (insertion order preserved)
+- `t::Float64` — time
+- `xlabel::String` — x-axis label
+- `title::String` — plot title
+"""
+struct FieldSnapshot1D
+    x::Vector{Float64}
+    fields::Vector{Pair{Symbol,Vector{Float64}}}
+    t::Float64
+    xlabel::String
+    title::String
+end
+
+# Single-field convenience constructor
+function FieldSnapshot1D(grid::UniformGrid1D, φ::AbstractVector, t::Real;
+                         field_name::Symbol=:φ, xlabel::String="x", title::String="")
+    length(φ) == grid.N || throw(ArgumentError(
+        "Field length $(length(φ)) does not match grid size $(grid.N)"))
+    FieldSnapshot1D(grid.x, [field_name => collect(Float64, φ)], Float64(t), xlabel, title)
+end
+
+# Multi-field constructor
+function FieldSnapshot1D(grid::UniformGrid1D, fields::Dict{Symbol,<:AbstractVector}, t::Real;
+                         xlabel::String="x", title::String="")
+    for (k, v) in fields
+        length(v) == grid.N || throw(ArgumentError(
+            "Field :$k length $(length(v)) does not match grid size $(grid.N)"))
+    end
+    pairs = [k => collect(Float64, v) for (k, v) in fields]
+    FieldSnapshot1D(grid.x, pairs, Float64(t), xlabel, title)
+end
+
+"""
+    SpaceTimeSnapshot1D
+
+1D field evolution over time, suitable for heatmap display.
+
+# Fields
+- `x::Vector{Float64}` — spatial coordinates (length N)
+- `t::Vector{Float64}` — time values (length M)
+- `data::Matrix{Float64}` — field values (N × M)
+- `field_name::Symbol` — field name for display
+- `xlabel::String` — x-axis label
+- `ylabel::String` — y-axis label (default: "Time")
+- `title::String` — plot title
+- `clims::Union{Nothing,Tuple{Float64,Float64}}` — color range
+- `colormap::Symbol` — colormap (default: :RdBu)
+"""
+struct SpaceTimeSnapshot1D
+    x::Vector{Float64}
+    t::Vector{Float64}
+    data::Matrix{Float64}
+    field_name::Symbol
+    xlabel::String
+    ylabel::String
+    title::String
+    clims::Union{Nothing,Tuple{Float64,Float64}}
+    colormap::Symbol
+
+    function SpaceTimeSnapshot1D(x, t, data, field_name;
+                                 xlabel="x", ylabel="Time", title="",
+                                 clims=nothing, colormap=:RdBu)
+        size(data) == (length(x), length(t)) || throw(ArgumentError(
+            "Data size $(size(data)) does not match ($(length(x)), $(length(t)))"))
+        new(collect(Float64, x), collect(Float64, t), collect(Float64, data),
+            field_name, xlabel, ylabel, title, clims, colormap)
+    end
+end
+
+"""
+    FieldSnapshot2D
+
+2D field snapshot at a specific time (single field, suitable for heatmap).
+
+# Fields
+- `x::Vector{Float64}` — x coordinates (length Nx)
+- `y::Vector{Float64}` — y coordinates (length Ny)
+- `field::Matrix{Float64}` — field values (Nx × Ny)
+- `t::Float64` — time
+- `field_name::Symbol` — field name for display
+- `xlabel::String`, `ylabel::String` — axis labels
+- `title::String` — plot title
+- `clims::Union{Nothing,Tuple{Float64,Float64}}` — color range
+- `colormap::Symbol` — colormap (default: :viridis)
+"""
+struct FieldSnapshot2D
+    x::Vector{Float64}
+    y::Vector{Float64}
+    field::Matrix{Float64}
+    t::Float64
+    field_name::Symbol
+    xlabel::String
+    ylabel::String
+    title::String
+    clims::Union{Nothing,Tuple{Float64,Float64}}
+    colormap::Symbol
+end
+
+function FieldSnapshot2D(grid::UniformGrid2D, field::AbstractMatrix, t::Real, field_name::Symbol;
+                         xlabel::String="x", ylabel::String="y", title::String="",
+                         clims=nothing, colormap::Symbol=:viridis)
+    size(field) == (grid.Nx, grid.Ny) || throw(ArgumentError(
+        "Field size $(size(field)) does not match grid size ($(grid.Nx), $(grid.Ny))"))
+    FieldSnapshot2D(grid.x, grid.y, collect(Float64, field), Float64(t),
+                    field_name, xlabel, ylabel, title, clims, colormap)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,9 @@ import DifferentiationInterface as DI
     include("test_grids_2d.jl")
     include("test_problems.jl")  # Test 1-7 only (solve tests separated)
 
+    # Snapshot types for plotting
+    include("test_snapshot.jl")
+
     # OpenCALPHAD extension (DB calls only, no solve)
     # Skip if OpenCALPHAD is not available (weakdep, not registered yet)
     if Base.find_package("OpenCALPHAD") !== nothing

--- a/test/test_snapshot.jl
+++ b/test/test_snapshot.jl
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026 Hiroharu Sugawara
+# Part of PhaseFields.jl - Tests for snapshot types
+
+@testset "FieldSnapshot1D" begin
+    grid = UniformGrid1D(N=50, L=10.0)
+    φ = rand(50)
+
+    # Single-field constructor
+    snap = FieldSnapshot1D(grid, φ, 1.0; field_name=:φ, title="Test")
+    @test snap isa FieldSnapshot1D
+    @test snap.x == grid.x
+    @test length(snap.fields) == 1
+    @test snap.fields[1].first == :φ
+    @test snap.fields[1].second ≈ φ
+    @test snap.t == 1.0
+    @test snap.title == "Test"
+
+    # Multi-field constructor
+    fields = Dict(:φ => rand(50), :c => rand(50))
+    snap2 = FieldSnapshot1D(grid, fields, 2.0)
+    @test length(snap2.fields) == 2
+
+    # Size mismatch error
+    @test_throws ArgumentError FieldSnapshot1D(grid, rand(30), 0.0)
+end
+
+@testset "SpaceTimeSnapshot1D" begin
+    x = collect(range(0, 1, length=30))
+    t = [0.0, 1.0, 2.0]
+    data = rand(30, 3)
+
+    snap = SpaceTimeSnapshot1D(x, t, data, :c)
+    @test snap isa SpaceTimeSnapshot1D
+    @test size(snap.data) == (30, 3)
+    @test snap.field_name == :c
+    @test snap.colormap == :RdBu
+
+    # Size mismatch error
+    @test_throws ArgumentError SpaceTimeSnapshot1D(x, t, rand(20, 3), :c)
+end
+
+@testset "FieldSnapshot2D" begin
+    grid = UniformGrid2D(Nx=20, Ny=20, Lx=1.0, Ly=1.0)
+    field = rand(20, 20)
+
+    snap = FieldSnapshot2D(grid, field, 0.5, :φ)
+    @test snap isa FieldSnapshot2D
+    @test size(snap.field) == (20, 20)
+    @test snap.t == 0.5
+    @test snap.field_name == :φ
+    @test snap.colormap == :viridis
+
+    # Size mismatch error
+    @test_throws ArgumentError FieldSnapshot2D(grid, rand(10, 20), 0.0, :φ)
+end
+
+@testset "savefig_publication fallback" begin
+    @test_throws ArgumentError savefig_publication(nothing, "x")
+end


### PR DESCRIPTION
- Add FieldSnapshot1D, SpaceTimeSnapshot1D, FieldSnapshot2D types
- Add RecipesBase plot recipes for all snapshot types
- Add plot_field/animate_field/savefig_publication stubs + fallback
- Add RecipesBase and PythonPlot as weakdeps

All 379 existing tests pass. No changes to existing examples or Colab demo.

Closes #11