### PR TITLE
Switch PythonPlot ext to mm units and add @docs docs parity

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,8 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 PhaseFields = "6af1007f-d462-454c-a7f3-5589aa52c87f"
+PythonPlot = "274fc56d-3b97-40fa-a1cd-1b4a50311bf9"
 
 [compat]
 Documenter = "1"
+PythonPlot = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,11 @@
 using Documenter
 using PhaseFields
+using PythonPlot                   # loads PhaseFieldsPythonPlotExt so its docstrings render
+PythonPlot.matplotlib.use("Agg")  # headless backend for CI
+
+# The PythonPlot extension carries the docstrings for plot_on_axis! /
+# figure_publication / savefig_publication; include it so @docs can render them.
+const PFPythonPlotExt = Base.get_extension(PhaseFields, :PhaseFieldsPythonPlotExt)
 
 makedocs(
     sitename = "PhaseFields.jl",
@@ -8,7 +14,7 @@ makedocs(
     format = Documenter.HTML(
         prettyurls = get(ENV, "CI", nothing) == "true",
     ),
-    modules = [PhaseFields],
+    modules = [PhaseFields, PFPythonPlotExt],
     checkdocs = :exports,  # Only check exported symbols
     warnonly = [:missing_docs, :cross_references],  # Don't fail on missing docs or unit brackets
     pages = [

--- a/docs/src/plotting.md
+++ b/docs/src/plotting.md
@@ -24,7 +24,7 @@ Plot one or more fields at a specific time step.
 **Single field:**
 
 ```julia
-grid = UniformGrid1D(0.0, 1.0, 101)
+grid = UniformGrid1D(N=101, L=1.0)
 snap = FieldSnapshot1D(grid, φ, t; field_name=:φ)
 plot(snap)
 ```
@@ -40,7 +40,7 @@ plot(snap)
 |-----------|---------|
 | xlabel | value of `snap.xlabel` (default `"x"`) |
 | ylabel | field name (e.g. `"φ"`) |
-| title | `"φ (t=0.5)"` (auto-generated from field name and time) |
+| title | `"φ (t=0.5)"` (generated from the field name and time) |
 | linewidth | 2 |
 | layout | `(n, 1)` for n fields |
 
@@ -68,7 +68,7 @@ plot(snap)
 Plot a 2D field at a specific time step as a heatmap.
 
 ```julia
-grid = UniformGrid2D(0.0, 1.0, 64, 0.0, 1.0, 64)
+grid = UniformGrid2D(Nx=64, Ny=64, Lx=1.0, Ly=1.0)
 snap = FieldSnapshot2D(grid, field, t, :φ;
     colormap=:viridis, clims=(0.0, 1.0))
 plot(snap)
@@ -98,29 +98,38 @@ plot(snap, title="Custom Title", seriescolor=:plasma, size=(800, 600))
 
 ## Publication-quality output (PythonPlot)
 
-`using PythonPlot` enables a three-layer [matplotlib](https://matplotlib.org/)-based
-API for publication figures. Install with `pkg> add PythonPlot` (matplotlib is
-provided automatically via Conda). These functions are not exported; call them as
-`PhaseFields.plot_on_axis!` / `PhaseFields.figure_publication`.
+For publication-quality static figures (PDF / PNG via matplotlib), load the
+PythonPlot extension. The API has **three layers** (L1 / L2 are unexported —
+call them as `PhaseFields.…`; L3 `savefig_publication` is exported). Install
+with `pkg> add PythonPlot` (matplotlib is provided automatically via Conda).
 
 | Layer | Function | Returns | Use |
 |-------|----------|---------|-----|
-| L1 | `PhaseFields.plot_on_axis!(ax, snap; ...)` | `ax` | draw onto your own matplotlib axis (compose subplots) |
-| L2 | `PhaseFields.figure_publication(snap; ...)` | `(fig, ax)` | get a sized figure + axis to tweak before saving |
-| L3 | `savefig_publication(snap, path; ...)` | `path` | one-shot save to PDF or PNG (by extension) |
+| L3 | `savefig_publication(snap, path; ...)` | `path` | save to PDF or PNG in one call (format from the file extension; delegates to L2) |
+| L2 | `PhaseFields.figure_publication(snap; ...)` | `(fig, ax)` | a sized figure + axis to tweak before saving |
+| L1 | `PhaseFields.plot_on_axis!(ax, snap; ...)` | `ax` | draw onto your own matplotlib axis (compose a subplot grid) |
 
 ```julia
 using PhaseFields, PythonPlot
+```
 
+On a headless machine or in CI (no display), select a non-interactive backend
+before plotting: `PythonPlot.matplotlib.use("Agg")`.
+
+In every layer the `snap` argument may be a `FieldSnapshot1D`,
+`SpaceTimeSnapshot1D`, or `FieldSnapshot2D`, plus an
+`AbstractVector{<:FieldSnapshot2D}` for an L3 panel grid.
+
+```julia
 grid = UniformGrid2D(Nx=64, Ny=64, Lx=1.0, Ly=1.0)
 snap = FieldSnapshot2D(grid, field, 0.5, :φ; colormap=:viridis)
 
-# L3 — one-shot save (format from the file extension)
+# L3 — save in one call (format from the file extension)
 savefig_publication(snap, "phi.pdf")
 savefig_publication(snap, "phi.png")
 
 # L2 — adjust before saving
-fig, ax = PhaseFields.figure_publication(snap; axis_width_cm=8.0, axis_height_cm=6.0)
+fig, ax = PhaseFields.figure_publication(snap; axis_width_mm=80.0, axis_height_mm=60.0)
 ax.set_title("My field")
 fig.savefig("phi_custom.pdf")
 PythonPlot.close(fig)
@@ -129,21 +138,23 @@ PythonPlot.close(fig)
 fig = PythonPlot.figure()
 ax = fig.add_subplot(1, 2, 1)
 PhaseFields.plot_on_axis!(ax, snap)
+fig.savefig("composite.pdf")
+PythonPlot.close(fig)
 ```
 
-Supported snapshots: `FieldSnapshot1D` (single field, or multiple fields stacked
-vertically by L3), `SpaceTimeSnapshot1D`, `FieldSnapshot2D`, and
-`AbstractVector{<:FieldSnapshot2D}` (panel grid via `layout=(rows, cols)`).
+With L1 and L2 you create the figure (via `PythonPlot.figure` / `add_subplot`),
+so you own it and must call `PythonPlot.close(fig)`; `savefig_publication` (L3)
+closes its figure for you.
 
-Common keyword arguments:
+### Keyword reference
 
-| Keyword | Applies to | Meaning |
-|---------|-----------|---------|
-| `axis_width_cm`, `axis_height_cm` | L2, L3 | physical axis size (default `8.0` × `6.0`) |
-| `clims` | L1, L2, L3 | color range `(vmin, vmax)` for heatmaps |
-| `colormap` | L1, L2, L3 | override `snap.colormap` |
-| `ylims` | L2, L3 single-axis | y-axis limits (not supported for vertical-stack / panel paths) |
-| `layout` | L3 vector | `(rows, cols)` panel arrangement |
+Keywords are documented on the functions below. The plot keywords for each
+snapshot type (and the label and title precedence) live on `plot_on_axis!`;
+`figure_publication` adds the figure size keywords; `savefig_publication`
+forwards everything:
 
-Labels and titles follow the recipe conventions: an explicit keyword wins, then
-`snap.xlabel` / `snap.ylabel` / `snap.title`, then an auto-generated default.
+```@docs
+PhaseFields.savefig_publication
+PhaseFields.figure_publication
+PhaseFields.plot_on_axis!
+```

--- a/ext/PhaseFieldsPythonPlotExt.jl
+++ b/ext/PhaseFieldsPythonPlotExt.jl
@@ -14,24 +14,24 @@ import PhaseFields: FieldSnapshot1D, SpaceTimeSnapshot1D, FieldSnapshot2D,
                     plot_on_axis!, figure_publication, savefig_publication
 import PythonPlot
 
-const CM_PER_INCH = 2.54
+const MM_PER_INCH = 25.4
 
-# ── ETB layout helper (shared pattern with OC/BT/PX PythonPlot ext) ──
-function _layout_axes(axis_width_cm, axis_height_cm, n;
-        margin_left_cm = 2.0, margin_right_cm = 0.3,
-        margin_bottom_cm = 1.5, margin_top_cm = 0.8,
-        hgap_cm = 1.8, vgap_cm = 1.5, nrows = 1, ncols = 1)
-    widths  = axis_width_cm  isa AbstractVector ? axis_width_cm  : fill(axis_width_cm,  ncols)
-    heights = axis_height_cm isa AbstractVector ? axis_height_cm : fill(axis_height_cm, nrows)
-    fig_w_cm = margin_left_cm   + sum(widths)  + hgap_cm * (ncols - 1) + margin_right_cm
-    fig_h_cm = margin_bottom_cm + sum(heights) + vgap_cm * (nrows - 1) + margin_top_cm
-    fig_w = fig_w_cm / CM_PER_INCH
-    fig_h = fig_h_cm / CM_PER_INCH
+# ── ETB layout helper (shared pattern with the OC PythonPlot ext) ──
+function _layout_axes(axis_width_mm, axis_height_mm, n;
+        margin_left_mm = 20.0, margin_right_mm = 3.0,
+        margin_bottom_mm = 15.0, margin_top_mm = 8.0,
+        hgap_mm = 18.0, vgap_mm = 15.0, nrows = 1, ncols = 1)
+    widths  = axis_width_mm  isa AbstractVector ? axis_width_mm  : fill(axis_width_mm,  ncols)
+    heights = axis_height_mm isa AbstractVector ? axis_height_mm : fill(axis_height_mm, nrows)
+    fig_w_mm = margin_left_mm   + sum(widths)  + hgap_mm * (ncols - 1) + margin_right_mm
+    fig_h_mm = margin_bottom_mm + sum(heights) + vgap_mm * (nrows - 1) + margin_top_mm
+    fig_w = fig_w_mm / MM_PER_INCH
+    fig_h = fig_h_mm / MM_PER_INCH
     positions = Vector{NTuple{4,Float64}}()
     for row in 1:nrows, col in 1:ncols
-        left   = (margin_left_cm   + sum(widths[1:(col - 1)])    + hgap_cm * (col - 1))   / fig_w_cm
-        bottom = (margin_bottom_cm + sum(heights[(row + 1):end]) + vgap_cm * (nrows - row)) / fig_h_cm
-        push!(positions, (left, bottom, widths[col] / fig_w_cm, heights[row] / fig_h_cm))
+        left   = (margin_left_mm   + sum(widths[1:(col - 1)])    + hgap_mm * (col - 1))   / fig_w_mm
+        bottom = (margin_bottom_mm + sum(heights[(row + 1):end]) + vgap_mm * (nrows - row)) / fig_h_mm
+        push!(positions, (left, bottom, widths[col] / fig_w_mm, heights[row] / fig_h_mm))
     end
     return fig_w, fig_h, positions
 end
@@ -52,6 +52,29 @@ _clims_kw(cl) = isnothing(cl) ? (;) : (vmin = cl[1], vmax = cl[2])
 # L1 — plot_on_axis!(ax, snap; ...) : mutate a user-supplied axis, return ax
 # ══════════════════════════════════════════════════════════════════════
 
+"""
+    plot_on_axis!(ax, snap::FieldSnapshot1D; kwargs...) -> ax
+
+Draw a [`FieldSnapshot1D`](@ref) onto the matplotlib axis you supply and return
+`ax`, so panels can be composed. A single field is drawn as a line; multiple
+fields are overlaid with a legend. Requires `using PythonPlot`; not exported
+(call as `PhaseFields.plot_on_axis!`).
+
+# Arguments
+
+- `ax`: a matplotlib axis (PythonCall `Py`) to draw onto
+- `snap::FieldSnapshot1D`: the 1D field snapshot to plot
+
+# Keywords
+
+- `color=nothing`: line color for a single field (matplotlib default when
+    `nothing`); multiple fields are colored automatically
+- `linewidth=2.0`: line width
+- `linestyle="-"`: line style for a single field
+- `xlabel::AbstractString=""`: x axis label; empty uses `snap.xlabel`
+- `ylabel::AbstractString=""`: y axis label; empty uses the field name
+- `title::AbstractString=""`: title; empty uses `snap.title` or an automatic title
+"""
 function PhaseFields.plot_on_axis!(ax, snap::FieldSnapshot1D;
         xlabel = "", ylabel = "", title = "",
         color = nothing, linewidth = 2.0, linestyle = "-")
@@ -76,6 +99,25 @@ function PhaseFields.plot_on_axis!(ax, snap::FieldSnapshot1D;
     return ax
 end
 
+"""
+    plot_on_axis!(ax, snap::SpaceTimeSnapshot1D; kwargs...) -> ax
+
+Draw a [`SpaceTimeSnapshot1D`](@ref) as a pcolormesh (with a colorbar) onto `ax`
+and return `ax`. Requires `using PythonPlot`; not exported.
+
+# Arguments
+
+- `ax`: a matplotlib axis (PythonCall `Py`) to draw onto
+- `snap::SpaceTimeSnapshot1D`: the space time field evolution to plot
+
+# Keywords
+
+- `colormap=nothing`: colormap; empty uses `snap.colormap`
+- `clims=nothing`: color range `(vmin, vmax)`; empty uses `snap.clims`
+- `xlabel::AbstractString=""`: x axis label; empty uses `snap.xlabel`
+- `ylabel::AbstractString=""`: y axis label; empty uses `snap.ylabel`
+- `title::AbstractString=""`: title; empty uses `snap.title` or the field name
+"""
 function PhaseFields.plot_on_axis!(ax, snap::SpaceTimeSnapshot1D;
         xlabel = "", ylabel = "", title = "", colormap = nothing, clims = nothing)
     cmap = String(isnothing(colormap) ? snap.colormap : colormap)
@@ -88,6 +130,25 @@ function PhaseFields.plot_on_axis!(ax, snap::SpaceTimeSnapshot1D;
     return ax
 end
 
+"""
+    plot_on_axis!(ax, snap::FieldSnapshot2D; kwargs...) -> ax
+
+Draw a [`FieldSnapshot2D`](@ref) as a pcolormesh (with a colorbar and equal
+aspect) onto `ax` and return `ax`. Requires `using PythonPlot`; not exported.
+
+# Arguments
+
+- `ax`: a matplotlib axis (PythonCall `Py`) to draw onto
+- `snap::FieldSnapshot2D`: the 2D field snapshot to plot
+
+# Keywords
+
+- `colormap=nothing`: colormap; empty uses `snap.colormap`
+- `clims=nothing`: color range `(vmin, vmax)`; empty uses `snap.clims`
+- `xlabel::AbstractString=""`: x axis label; empty uses `snap.xlabel`
+- `ylabel::AbstractString=""`: y axis label; empty uses `snap.ylabel`
+- `title::AbstractString=""`: title; empty uses `snap.title` or an automatic title
+"""
 function PhaseFields.plot_on_axis!(ax, snap::FieldSnapshot2D;
         xlabel = "", ylabel = "", title = "", colormap = nothing, clims = nothing)
     cmap = String(isnothing(colormap) ? snap.colormap : colormap)
@@ -105,12 +166,32 @@ end
 # L2 — figure_publication(snap; ...) : create (fig, ax), single axis
 # ══════════════════════════════════════════════════════════════════════
 
+"""
+    figure_publication(snap; axis_width_mm=80.0, axis_height_mm=60.0, ylims=nothing, kwargs...) -> (fig, ax)
+
+Create a publication matplotlib figure and a single axis for `snap`, draw it via
+[`plot_on_axis!`](@ref), and return `(fig, ax)` so you can tweak it before
+saving. The caller owns the figure and must call `PythonPlot.close(fig)`.
+Requires `using PythonPlot`; not exported (call as `PhaseFields.figure_publication`).
+
+# Arguments
+
+- `snap`: a `FieldSnapshot1D`, `SpaceTimeSnapshot1D`, or `FieldSnapshot2D`
+
+# Keywords
+
+- `axis_width_mm=80.0`: plotting area width in mm
+- `axis_height_mm=60.0`: plotting area height in mm
+- `ylims=nothing`: pass a tuple to override the y axis limits
+- `kwargs...`: forwarded to [`plot_on_axis!`](@ref)
+"""
 function PhaseFields.figure_publication(
         snap::Union{FieldSnapshot1D,SpaceTimeSnapshot1D,FieldSnapshot2D};
-        axis_width_cm = 8.0, axis_height_cm = 6.0, margin_right_cm = 1.5,
+        axis_width_mm = 80.0, axis_height_mm = 60.0,
         ylims = nothing, kwargs...)
-    fig_w, fig_h, positions = _layout_axes(axis_width_cm, axis_height_cm, 1;
-                                           margin_right_cm = margin_right_cm)
+    # margin_right widened to leave room for the colorbar on heatmap snapshots
+    fig_w, fig_h, positions = _layout_axes(axis_width_mm, axis_height_mm, 1;
+                                           margin_right_mm = 15.0)
     fig = PythonPlot.figure(figsize = (fig_w, fig_h))
     try
         ax = fig.add_axes(collect(positions[1]))
@@ -125,8 +206,9 @@ end
 
 # ══════════════════════════════════════════════════════════════════════
 # L3 — savefig_publication(snap, path; ...) : L2 + savefig + close
-# (all methods type-specific; no untyped catch-all to avoid shadowing the
-#  src fallback)
+# (type-specific methods; no untyped catch-all to avoid shadowing the
+#  src fallback. The public docstring is attached to the FieldSnapshot1D
+#  method and describes all variants.)
 # ══════════════════════════════════════════════════════════════════════
 
 function PhaseFields.savefig_publication(snap::SpaceTimeSnapshot1D, path; kwargs...)
@@ -149,11 +231,34 @@ function PhaseFields.savefig_publication(snap::FieldSnapshot2D, path; kwargs...)
     return path
 end
 
+"""
+    savefig_publication(snap, path; kwargs...) -> path
+
+Render `snap` to `path` and return `path`; the output format follows the file
+extension (`.pdf` or `.png`). This is the convenience entry point (the only
+exported layer): it delegates to [`figure_publication`](@ref) and closes the
+figure for you. A multi field `FieldSnapshot1D` is drawn as a vertical stack of
+panels, and an `AbstractVector{<:FieldSnapshot2D}` as a `layout=(rows, cols)`
+grid. Requires `using PythonPlot`.
+
+# Arguments
+
+- `snap`: a `FieldSnapshot1D`, `SpaceTimeSnapshot1D`, `FieldSnapshot2D`, or
+    `AbstractVector{<:FieldSnapshot2D}`
+- `path::AbstractString`: output file; the extension selects PDF or PNG
+
+# Keywords
+
+- `axis_width_mm=80.0`, `axis_height_mm=60.0`: panel size in mm
+- `layout=(1, n)`: grid arrangement for a vector of 2D snapshots
+- `kwargs...`: forwarded through [`figure_publication`](@ref) to
+    [`plot_on_axis!`](@ref) (including any plot styling)
+"""
 function PhaseFields.savefig_publication(snap::FieldSnapshot1D, path;
-        axis_width_cm = 8.0, axis_height_cm = 6.0, kwargs...)
+        axis_width_mm = 80.0, axis_height_mm = 60.0, kwargs...)
     if length(snap.fields) == 1
         fig, _ = figure_publication(snap;
-                    axis_width_cm = axis_width_cm, axis_height_cm = axis_height_cm, kwargs...)
+                    axis_width_mm = axis_width_mm, axis_height_mm = axis_height_mm, kwargs...)
         try
             fig.savefig(path)
         finally
@@ -161,7 +266,7 @@ function PhaseFields.savefig_publication(snap::FieldSnapshot1D, path;
         end
     else
         n = length(snap.fields)
-        fig_w, fig_h, positions = _layout_axes(axis_width_cm, axis_height_cm, n;
+        fig_w, fig_h, positions = _layout_axes(axis_width_mm, axis_height_mm, n;
                                                nrows = n, ncols = 1)
         fig = PythonPlot.figure(figsize = (fig_w, fig_h))
         try
@@ -170,7 +275,8 @@ function PhaseFields.savefig_publication(snap::FieldSnapshot1D, path;
                 sub = _single_field_view(snap, sym, vals)
                 plot_on_axis!(ax, sub;
                               xlabel = (i == n ? snap.xlabel : ""),
-                              title  = (i == 1 ? snap.title : ""))
+                              title  = (i == 1 ? snap.title : ""),
+                              kwargs...)
             end
             fig.savefig(path)
         finally
@@ -182,9 +288,9 @@ end
 
 function PhaseFields.savefig_publication(snaps::AbstractVector{<:FieldSnapshot2D}, path;
         layout = (1, length(snaps)),
-        axis_width_cm = 8.0, axis_height_cm = 6.0, kwargs...)
+        axis_width_mm = 80.0, axis_height_mm = 60.0, kwargs...)
     nrows, ncols = layout
-    fig_w, fig_h, positions = _layout_axes(axis_width_cm, axis_height_cm, length(snaps);
+    fig_w, fig_h, positions = _layout_axes(axis_width_mm, axis_height_mm, length(snaps);
                                            nrows = nrows, ncols = ncols)
     fig = PythonPlot.figure(figsize = (fig_w, fig_h))
     try

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -21,44 +21,26 @@ Create animation from snapshots. Requires `using Plots`.
 """
 function animate_field end
 
-"""
-    savefig_publication(snap, filepath; kwargs...)
-
-Save publication-quality figure. Requires `using PythonPlot`.
-"""
+# PythonPlot extension API (3-layer). Implemented — with their authoritative,
+# per-method docstrings — in ext/PhaseFieldsPythonPlotExt.jl. The extension
+# module is added to Documenter's `modules` so `@docs` renders those docstrings.
 function savefig_publication end
+function plot_on_axis! end
+function figure_publication end
 
-# Fallback
+# Fallbacks (when PythonPlot is not loaded)
 function savefig_publication(args...; kwargs...)
     throw(ArgumentError(
         "savefig_publication requires PythonPlot.jl. Run `using PythonPlot` first."
     ))
 end
 
-"""
-    plot_on_axis!(ax, snap; kwargs...)
-
-Draw a snapshot onto a user-supplied matplotlib axis and return `ax`.
-Requires `using PythonPlot`. Not exported; call as `PhaseFields.plot_on_axis!`.
-"""
-function plot_on_axis! end
-
-# Fallback
 function plot_on_axis!(args...; kwargs...)
     throw(ArgumentError(
         "plot_on_axis! requires PythonPlot.jl. Run `using PythonPlot` first."
     ))
 end
 
-"""
-    figure_publication(snap; kwargs...)
-
-Create a publication figure and axis for a snapshot, returning `(fig, ax)`.
-Requires `using PythonPlot`. Not exported; call as `PhaseFields.figure_publication`.
-"""
-function figure_publication end
-
-# Fallback
 function figure_publication(args...; kwargs...)
     throw(ArgumentError(
         "figure_publication requires PythonPlot.jl. Run `using PythonPlot` first."

--- a/test/test_publication.jl
+++ b/test/test_publication.jl
@@ -77,7 +77,7 @@ _title(ax) = string(ax.get_title())
     @testset "L3 custom axis size" begin
         mktempdir() do tmp
             p = joinpath(tmp, "custom.pdf")
-            savefig_publication(s1_single, p; axis_width_cm = 10.0, axis_height_cm = 5.0)
+            savefig_publication(s1_single, p; axis_width_mm = 100.0, axis_height_mm = 50.0)
             @test isfile(p)
         end
     end


### PR DESCRIPTION
See the commit for details.

- `Pkg.test()`: 401 PASS
- `docs/make.jl`: clean build; the three layer docstrings render via `@docs`