### PR TITLE
Add explicit token to TagBot

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -17,3 +17,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Aligns TagBot with the proven OpenCALPHAD.jl configuration; the previous workflow omitted the explicit GITHUB_TOKEN and TagBot has not yet run for this repo.