### PR TITLE
Release v0.2.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,14 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+title: "PhaseFields.jl: Phase field simulations with CALPHAD coupling in Julia"
+type: software
+authors:
+  - family-names: Sugawara
+    given-names: Hiroharu
+    email: hsugawa@gmail.com
+    orcid: "https://orcid.org/0000-0002-0071-2396"
+license: MIT
+repository-code: "https://github.com/hsugawa8651/PhaseFields.jl"
+version: 0.2.0
+date-released: 2026-05-31
+doi: 10.5281/zenodo.18649171

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PhaseFields"
 uuid = "6af1007f-d462-454c-a7f3-5589aa52c87f"
 authors = ["Hiroharu Sugawara <hsugawa@tmu.ac.jp>"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A Julia package for phase field simulations with CALPHAD thermodynamics coupling.
 
-## Features (v0.1)
+## Features (v0.2)
 
 * Multiple phase field models (Allen-Cahn, Cahn-Hilliard, KKS, WBM, Thermal)
 * 1D and 2D simulations (FDM built-in, FEM via Gridap.jl extension)
@@ -14,6 +14,7 @@ A Julia package for phase field simulations with CALPHAD thermodynamics coupling
 * DifferentialEquations.jl integration (adaptive time stepping, callbacks)
 * OpenCALPHAD.jl CALPHAD coupling via Package Extension
 * Automatic differentiation via DifferentiationInterface.jl
+* Publication-quality plotting via a PythonPlot extension (3-layer API) and Plots recipes
 
 ## Models
 


### PR DESCRIPTION
Bump version 0.1.0 -> 0.2.0, add CITATION.cff (all-versions Zenodo DOI), and note the PythonPlot 3-layer plotting API in the README.

Registration follows after merge via a JuliaRegistrator comment.