### PR TITLE
Use Zenodo concept DOI for badge and citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,4 +11,4 @@ license: MIT
 repository-code: "https://github.com/hsugawa8651/PhaseFields.jl"
 version: 0.2.0
 date-released: 2026-05-31
-doi: 10.5281/zenodo.18649171
+doi: 10.5281/zenodo.18649170

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/hsugawa8651/PhaseFields.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/hsugawa8651/PhaseFields.jl/actions/workflows/CI.yml)
 [![Documentation](https://github.com/hsugawa8651/PhaseFields.jl/actions/workflows/Docs.yml/badge.svg)](https://hsugawa8651.github.io/PhaseFields.jl/dev/)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18649171.svg)](https://doi.org/10.5281/zenodo.18649171)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18649170.svg)](https://doi.org/10.5281/zenodo.18649170)
 
 A Julia package for phase field simulations with CALPHAD thermodynamics coupling.
 


### PR DESCRIPTION
The README badge and CITATION.cff used the v0.1.0 version DOI (zenodo.18649171). Switch to the concept DOI (zenodo.18649170), which always resolves to the latest version.